### PR TITLE
feat: resolve percentage value in translate style

### DIFF
--- a/src/core/normalizer/index.ts
+++ b/src/core/normalizer/index.ts
@@ -5,9 +5,15 @@ import { clearStyle, mapValues, readStyle, writeStyle } from '../utils'
 import { NormalizerRule } from './normalizer'
 import { keywordValueRule } from './rules/keyword-value'
 import { mismatchGeneralRule } from './rules/mismatch-general'
+import { translatePercentageRule } from './rules/translate-percentage'
 import { zeroValueRule } from './rules/zero-value'
 
-const allRules: NormalizerRule[] = [keywordValueRule, zeroValueRule, mismatchGeneralRule]
+const allRules: NormalizerRule[] = [
+  keywordValueRule,
+  zeroValueRule,
+  translatePercentageRule,
+  mismatchGeneralRule,
+]
 
 /**
  * Convert raw user-provided `from` / `to` styles into pairs of numeric style

--- a/src/core/normalizer/rules/translate-percentage.ts
+++ b/src/core/normalizer/rules/translate-percentage.ts
@@ -1,0 +1,118 @@
+import { AnimationTarget } from '../../animate'
+import { NormalizerRule, matchedIndexes } from '../normalizer'
+
+/**
+ * Resolve percentage components of the individual `translate` property to
+ * pixels when the matching endpoint component is already in pixels.
+ *
+ * Unlike ordinary lengths, percentages remain percentages in the computed
+ * value of the individual `translate` property. Evaluating the same value as
+ * a transform function makes the browser resolve it against the element's
+ * transform reference box and serialize the result as a matrix, whose
+ * translation components are pixel values.
+ */
+export const translatePercentageRule: NormalizerRule = (el, key, target, counterpart) => {
+  if (key !== 'translate' || !isSimpleTranslate(target)) {
+    return target
+  }
+
+  const indexes = matchedIndexes(target, counterpart, (t, c) => t.unit === '%' && c.unit === 'px')
+
+  if (indexes.length === 0) {
+    return target
+  }
+
+  const translation = probeTranslateMatrix(el, target.values, target.units)
+  if (translation === undefined) {
+    return target
+  }
+
+  const values = [...target.values]
+  const units = [...target.units]
+  for (const index of indexes) {
+    values[index] = translation[index]!
+    units[index] = 'px'
+  }
+
+  return {
+    ...target,
+    values,
+    units,
+  }
+}
+
+/**
+ * The generic style parser treats every number as an animation slot. Restrict
+ * this rule to the plain one-to-three-component grammar so an expression such
+ * as `calc(50% + 10px)` is not incorrectly treated as two translate axes.
+ */
+function isSimpleTranslate(value: { values: number[]; wraps: string[] }): boolean {
+  return (
+    value.values.length >= 1 &&
+    value.values.length <= 3 &&
+    value.wraps.every((wrap) => /^\s*$/.test(wrap))
+  )
+}
+
+/**
+ * Get actual computed value of translate style with px unit.
+ * values and units must be the same length array and their lengths must be
+ * between one to three.
+ */
+function probeTranslateMatrix(
+  el: AnimationTarget,
+  values: number[],
+  units: string[],
+): [number, number, number] | undefined {
+  const components = values.map((value, index) => `${value}${units[index] ?? ''}`)
+  const transform =
+    components.length === 3
+      ? `translate3d(${components.join(', ')})`
+      : `translate(${components.join(', ')})`
+
+  const style = el.style
+  const originalValue = style.getPropertyValue('transform')
+  const originalPriority = style.getPropertyPriority('transform')
+
+  try {
+    // Clear first so an invalid probe cannot silently leave the old inline
+    // transform in place and make us read an unrelated matrix.
+    style.removeProperty('transform')
+    style.setProperty('transform', transform, 'important')
+
+    // Since we clear the old value above, we check empty string
+    // to check the transform value is invalid,
+    if (style.getPropertyValue('transform') === '') {
+      return undefined
+    }
+
+    return parseMatrixTranslation(getComputedStyle(el).transform)
+  } finally {
+    if (originalValue === '') {
+      style.removeProperty('transform')
+    } else {
+      style.setProperty('transform', originalValue, originalPriority)
+    }
+  }
+}
+
+function parseMatrixTranslation(value: string): [number, number, number] | undefined {
+  const matrix3d = /^matrix3d\((.*)\)$/.exec(value.trim())
+  if (matrix3d) {
+    const entries = parseMatrixEntries(matrix3d[1]!, 16)
+    return entries === undefined ? undefined : [entries[12]!, entries[13]!, entries[14]!]
+  }
+
+  const matrix = /^matrix\((.*)\)$/.exec(value.trim())
+  if (matrix) {
+    const entries = parseMatrixEntries(matrix[1]!, 6)
+    return entries === undefined ? undefined : [entries[4]!, entries[5]!, 0]
+  }
+
+  return undefined
+}
+
+function parseMatrixEntries(value: string, expectedLength: number): number[] | undefined {
+  const entries = value.split(',').map((part) => Number(part.trim()))
+  return entries.length === expectedLength && entries.every(Number.isFinite) ? entries : undefined
+}

--- a/test/core/normalizer.test.ts
+++ b/test/core/normalizer.test.ts
@@ -185,6 +185,126 @@ describe('normalizeAnimationStyles', () => {
     })
   })
 
+  describe('translate percentages', () => {
+    test('resolves a percentage from component to px through a transform matrix', () => {
+      const target = el()
+      mockComputedStyles(target, {
+        transform: () => {
+          expect(target.style.transform).toBe('translate(50%)')
+          return 'matrix(1, 0, 0, 1, 160, 0)'
+        },
+      })
+
+      const result = normalizeAnimationStyles(target, { translate: '50%' }, { translate: '100px' })
+
+      expect(result.translate?.[0]).toEqual({
+        values: [160],
+        units: ['px'],
+        wraps: ['', ''],
+      })
+      expect(result.translate?.[1]).toEqual({
+        values: [100],
+        units: ['px'],
+        wraps: ['', ''],
+      })
+    })
+
+    test('resolves a percentage to component to px', () => {
+      const target = el()
+      mockComputedStyles(target, {
+        transform: 'matrix(1, 0, 0, 1, 80, 0)',
+      })
+
+      const result = normalizeAnimationStyles(target, { translate: '100px' }, { translate: '25%' })
+
+      expect(result.translate?.[0]?.values).toEqual([100])
+      expect(result.translate?.[1]?.values).toEqual([80])
+      expect(result.translate?.[1]?.units).toEqual(['px'])
+    })
+
+    test('resolves crossed percentage components independently', () => {
+      const target = el()
+      mockComputedStyles(target, {
+        transform: () => {
+          if (target.style.transform === 'translate(50%, 20px)') {
+            return 'matrix(1, 0, 0, 1, 160, 20)'
+          }
+          if (target.style.transform === 'translate(100px, 25%)') {
+            return 'matrix(1, 0, 0, 1, 100, 60)'
+          }
+          return 'none'
+        },
+      })
+
+      const result = normalizeAnimationStyles(
+        target,
+        { translate: '50% 20px' },
+        { translate: '100px 25%' },
+      )
+
+      expect(result.translate?.[0]?.values).toEqual([160, 20])
+      expect(result.translate?.[0]?.units).toEqual(['px', 'px'])
+      expect(result.translate?.[1]?.values).toEqual([100, 60])
+      expect(result.translate?.[1]?.units).toEqual(['px', 'px'])
+    })
+
+    test('reads xyz translation from a matrix3d serialization', () => {
+      const target = el()
+      mockComputedStyles(target, {
+        transform: () => {
+          expect(target.style.transform).toBe('translate3d(50%, 25%, 10px)')
+          return 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 160, 60, 10, 1)'
+        },
+      })
+
+      const result = normalizeAnimationStyles(
+        target,
+        { translate: '50% 25% 10px' },
+        { translate: '100px 100px 20px' },
+      )
+
+      expect(result.translate?.[0]?.values).toEqual([160, 60, 10])
+      expect(result.translate?.[0]?.units).toEqual(['px', 'px', 'px'])
+    })
+
+    test('restores the previous inline transform value and priority', () => {
+      const target = el()
+      target.style.setProperty('transform', 'rotate(10deg)', 'important')
+      mockComputedStyles(target, {
+        transform: 'matrix(1, 0, 0, 1, 160, 0)',
+      })
+
+      normalizeAnimationStyles(target, { translate: '50%' }, { translate: '100px' })
+
+      expect(target.style.transform).toBe('rotate(10deg)')
+      expect(target.style.getPropertyPriority('transform')).toBe('important')
+    })
+
+    test('skips compound expressions whose numeric slots do not map to axes', () => {
+      const target = el()
+
+      const result = normalizeAnimationStyles(
+        target,
+        { translate: 'calc(50% + 10px)' },
+        { translate: '100px' },
+      )
+
+      expect(result.translate?.[0]?.values).toEqual([50, 10])
+      expect(result.translate?.[0]?.units).toEqual(['%', 'px'])
+    })
+
+    test('keeps the authored percentage when matrix serialization is unavailable', () => {
+      const target = el()
+      mockComputedStyles(target, { transform: 'none' })
+
+      const result = normalizeAnimationStyles(target, { translate: '50%' }, { translate: '100px' })
+
+      expect(result.translate?.[0]?.values).toEqual([50])
+      expect(result.translate?.[0]?.units).toEqual(['%'])
+      expect(target.style.transform).toBe('')
+    })
+  })
+
   describe('mismatch resolution', () => {
     test('resolves a non-px `from` to px when `to` is px', () => {
       const target = el()


### PR DESCRIPTION
This PR allows users to animate `translate` styles between percentage value and px value. e.g.:

```
translate: 100%; -> translate: 20px;
```

The normalizer set `transform: translate(100%);` and get its transform matrix from computed style, then extract translate component from the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation style normalization for `translate` values that combine percentages and pixels.
  * Percentage-based translations now resolve to pixel values when browser transform data is available, including 2D and 3D translations.
  * Unsupported or ambiguous expressions retain their original values.
  * Original inline transform styling, including priority, is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->